### PR TITLE
project 2 - userprog: implement syscalls, fork/wait/exec, ROX, and dup2 

### DIFF
--- a/pintos/filesys/file.c
+++ b/pintos/filesys/file.c
@@ -3,12 +3,6 @@
 #include "filesys/inode.h"
 #include "threads/malloc.h"
 
-/* An open file. */
-struct file {
-	struct inode *inode;        /* File's inode. */
-	off_t pos;                  /* Current position. */
-	bool deny_write;            /* Has file_deny_write() been called? */
-};
 
 /* Opens a file for the given INODE, of which it takes ownership,
  * and returns the new file.  Returns a null pointer if an
@@ -20,6 +14,7 @@ file_open (struct inode *inode) {
 		file->inode = inode;
 		file->pos = 0;
 		file->deny_write = false;
+		file->ref_cnt = 1;
 		return file;
 	} else {
 		inode_close (inode);
@@ -51,6 +46,7 @@ file_duplicate (struct file *file) {
 /* Closes FILE. */
 void
 file_close (struct file *file) {
+	
 	if (file != NULL) {
 		file_allow_write (file);
 		inode_close (file->inode);

--- a/pintos/include/filesys/file.h
+++ b/pintos/include/filesys/file.h
@@ -2,8 +2,16 @@
 #define FILESYS_FILE_H
 
 #include "filesys/off_t.h"
-
+#include <stdbool.h>
 struct inode;
+
+/* An open file. */
+struct file {
+	struct inode *inode;        /* File's inode. */
+	off_t pos;                  /* Current position. */
+	bool deny_write;            /* Has file_deny_write() been called? */
+	int ref_cnt;
+};
 
 /* Opening and closing files. */
 struct file *file_open (struct inode *);

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -108,6 +108,8 @@ struct thread {
     struct list children;       // 자식들 리스트
     struct child_info *child_info;
 
+	struct file *exec_file;             /* Executable file kept open while running. */
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -10,7 +10,6 @@
 #include "vm/vm.h"
 #endif
 
-
 /* States in a thread's life cycle. */
 enum thread_status {
 	THREAD_RUNNING,     /* Running thread. */
@@ -107,11 +106,7 @@ struct thread {
  
     /* 자식 관리용 */
     struct list children;       // 자식들 리스트
-    struct list_elem child_elem;
-
-	/* for fork */
-    struct semaphore fork_sema;  
-    bool fork_success; 
+    struct child_info *child_info;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -101,6 +101,8 @@ struct thread {
 	struct list donations;  // 기부 기록 용
 	struct list_elem donation_elem;     // 'donations' 리스트에 연결하기 위한 리스트 요소
 
+	//fd table
+	struct file *fd_table[64];
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -102,7 +102,7 @@ struct thread {
 	struct list_elem donation_elem;     // 'donations' 리스트에 연결하기 위한 리스트 요소
 
 	//fd table
-	struct file *fd_table[64];
+	struct file **fd_table; 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "threads/synch.h" // for sema
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -103,6 +104,15 @@ struct thread {
 
 	//fd table
 	struct file **fd_table; 
+ 
+    /* 자식 관리용 */
+    struct list children;       // 자식들 리스트
+    struct list_elem child_elem;
+
+	/* for fork */
+    struct semaphore fork_sema;  
+    bool fork_success; 
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -3,6 +3,11 @@
 
 #include "threads/thread.h"
 
+struct fork_aux_arg{
+    struct thread *parent;
+    struct intr_frame parent_if;
+};
+
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -3,10 +3,24 @@
 
 #include "threads/thread.h"
 
-struct fork_aux_arg{
-    struct thread *parent;
-    struct intr_frame parent_if;
+struct fork_aux_arg {
+    struct thread *parent;          
+    struct intr_frame parent_if;    // 부모의 intr_frame 
+    struct semaphore fork_sema;          // 부모를 깨울 세마포어
+    bool success;                    // 자식 초기화 성공 여부
 };
+
+struct child_info;
+
+struct child_info {
+    tid_t tid;                 
+    int exit_status;           /*자식의 exit(status)*/
+    bool is_exited;            /* 자식이 정말로 종료됐는지 */
+    bool waited;
+    struct semaphore wait_sema;     /* 부모를 잠재우고 깨울 세마포어 */
+    struct list_elem elem;     
+};
+
 
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -3,4 +3,7 @@
 
 void syscall_init (void);
 
+#define STDIN_SENTINEL  ((struct file *) 1)
+#define STDOUT_SENTINEL ((struct file *) 2)
+
 #endif /* userprog/syscall.h */

--- a/pintos/tests/userprog/dup2/dup2-complex.c
+++ b/pintos/tests/userprog/dup2/dup2-complex.c
@@ -32,14 +32,12 @@ main (int argc UNUSED, char *argv[] UNUSED) {
   CHECK ((fd2 = open ("sample.txt")) > -1, "open \"sample.txt\"");
 
   buffer = get_boundary_area () - sizeof sample / 2;
-
   byte_cnt += read (fd1, buffer + byte_cnt, 10);
 
   seek (fd2, 10);
   byte_cnt += read (fd2, buffer + byte_cnt, 10);
 
   CHECK (dup2 (fd2, fd3) > 1, "first dup2()");
-
   byte_cnt += read (fd3, buffer + byte_cnt, 10);
 
   seek (fd1, 15);
@@ -62,7 +60,6 @@ main (int argc UNUSED, char *argv[] UNUSED) {
 
   for (fd5 = 10; fd5 == fd1 || fd5 == fd2 || fd5 == fd3 || fd5 == fd4; fd5++){}
   dup2 (1, fd5);
-
   write (fd5, magic, sizeof magic - 1);
 
   create ("cheer", sizeof sample);
@@ -70,13 +67,11 @@ main (int argc UNUSED, char *argv[] UNUSED) {
   
   fd4 = open ("cheer");
   fd6 = open ("up");
-
   dup2 (fd6, 1);
 
   msg ("%d", byte_cnt);
   snprintf (magic, sizeof magic, "%d", byte_cnt);
   write (fd4, magic, strlen (magic));
-
   pid_t pid;
   if (!(pid = fork ("child"))){ // child
     msg ("child begin");

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -230,6 +230,7 @@ thread_create (const char *name, int priority,
         /* 자식 쪽에서도 자기 child_info 를 가리키도록 연결 */
         t->child_info = ci_info;
 	} else{
+		palloc_free_page (t);
 		return TID_ERROR;
 	}
 #endif

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -516,10 +516,6 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->waiting_lock = NULL;
 	list_init(&t->donations);
 
-	//fd_table 초기화 
-	for (int i = 2; i < 64; i++) {
-        t->fd_table[i] = NULL;
-    }
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -11,6 +11,7 @@
 #include "threads/synch.h"
 #include "threads/vaddr.h"
 #include "intrinsic.h"
+#include "userprog/syscall.h"
 #ifdef USERPROG
 #include "userprog/process.h"
 #endif

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -215,6 +215,10 @@ thread_create (const char *name, int priority,
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
+	// parent–child 연결
+	struct thread *cur = thread_current();
+	list_push_back(&cur->children, &t->child_elem);
+
 	/* Call the kernel_thread if it scheduled.
 	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
 	t->tf.rip = (uintptr_t) kernel_thread;
@@ -515,6 +519,11 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->base_priority = priority;
 	t->waiting_lock = NULL;
 	list_init(&t->donations);
+
+   	/* ----- fork 동기화 관련 필드 초기화 ----- */
+	list_init (&t->children);        // 자식 리스트 초기화
+    sema_init (&t->fork_sema, 0);
+    t->fork_success = false;
 
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -539,6 +539,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 	list_init (&t->children); 
     t->child_info = NULL;       
 
+	t->exec_file = NULL;
+	t->fd_table = NULL; 
+
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -517,7 +517,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	list_init(&t->donations);
 
 	//fd_table 초기화 
-	for (int i = 3; i < 64; i++) {
+	for (int i = 2; i < 64; i++) {
         t->fd_table[i] = NULL;
     }
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -515,6 +515,11 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->base_priority = priority;
 	t->waiting_lock = NULL;
 	list_init(&t->donations);
+
+	//fd_table 초기화 
+	for (int i = 3; i < 64; i++) {
+        t->fd_table[i] = NULL;
+    }
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -200,7 +200,7 @@ thread_print_stats (void) {
    Priority scheduling is the goal of Problem 1-3. */
 tid_t
 thread_create (const char *name, int priority,
-		thread_func *function, void *aux) {
+	thread_func *function, void *aux) {
 	struct thread *t;
 	tid_t tid;
 
@@ -215,10 +215,24 @@ thread_create (const char *name, int priority,
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
-	// parent–child 연결
-	struct thread *cur = thread_current();
-	list_push_back(&cur->children, &t->child_elem);
-
+#ifdef USERPROG
+    /* ----- child_info 생성해서 부모에 등록 ----- */
+    struct thread *parent = thread_current();
+    struct child_info *ci_info = palloc_get_page(PAL_ZERO);
+    if (ci_info != NULL) {
+        ci_info->tid = tid;
+        ci_info->exit_status = -1;
+        ci_info->is_exited = false;
+        ci_info->waited = false;
+        sema_init(&ci_info->wait_sema, 0);
+    
+		list_push_back(&parent->children, &ci_info->elem);
+        /* 자식 쪽에서도 자기 child_info 를 가리키도록 연결 */
+        t->child_info = ci_info;
+	} else{
+		return TID_ERROR;
+	}
+#endif
 	/* Call the kernel_thread if it scheduled.
 	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
 	t->tf.rip = (uintptr_t) kernel_thread;
@@ -520,10 +534,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->waiting_lock = NULL;
 	list_init(&t->donations);
 
-   	/* ----- fork 동기화 관련 필드 초기화 ----- */
-	list_init (&t->children);        // 자식 리스트 초기화
-    sema_init (&t->fork_sema, 0);
-    t->fork_success = false;
+	/* 자식 관리용 초기화 */
+	list_init (&t->children); 
+    t->child_info = NULL;       
 
 }
 

--- a/pintos/userprog/Make.vars
+++ b/pintos/userprog/Make.vars
@@ -7,6 +7,6 @@ TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/thre
 GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.no-extra
 
 # Uncomment the lines below to submit/test extra for project 2.
-# TDEFINE := -DEXTRA2
-# TEST_SUBDIRS += tests/userprog/dup2
-# GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra
+TDEFINE := -DEXTRA2
+TEST_SUBDIRS += tests/userprog/dup2
+GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -149,6 +149,10 @@ page_fault (struct intr_frame *f) {
 	/* Count page faults. */
 	page_fault_cnt++;
 
+	if(user){
+		sys_exit(-1);
+	}
+
 	/* If the fault is true fault, show info and exit. */
 	printf ("Page fault at %p: %s error %s page in %s context.\n",
 			fault_addr,

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -229,7 +229,7 @@ process_exit (void) {
 	 * TODO: We recommend you to implement process resource cleanup here. */
 
 	/* 파일 디스크립터 정리 */
-    for (int i = 3; i < 64; i++) {
+    for (int i = 2; i < 64; i++) {
 		sys_close(i);
     }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -228,6 +228,11 @@ process_exit (void) {
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
 
+	/* 파일 디스크립터 정리 */
+    for (int i = 3; i < 64; i++) {
+		sys_close(i);
+    }
+
 	process_cleanup ();
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -217,7 +217,7 @@ __do_fork (void *aux) {
         	struct file *dup = file_duplicate (f);
             	if (dup == NULL) {
                 	succ = false;
-               	break;thread_wait
+               	break;
             	}
             current->fd_table[fd] = dup;
         }
@@ -242,7 +242,7 @@ done:
  * Returns -1 on fail. */
 int
 process_exec (void *f_name) {
-	char *file_name = f_name; 		//void to char 
+	char *cmd_line = f_name; 
 	bool success;
 
 	/* We cannot use the intr_frame in the thread structure.
@@ -250,6 +250,7 @@ process_exec (void *f_name) {
 	 * it stores the execution information to the member. */
 	/* 사용자 모드로 전환하기 위해 레지스터를 수동 조작 및 초기화 (Fake Interrupt Frame) */	
 	struct intr_frame _if;
+
 	_if.ds = _if.es = _if.ss = SEL_UDSEG;
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
@@ -258,10 +259,10 @@ process_exec (void *f_name) {
 	process_cleanup ();
 
 	/* And then load the binary */
-	success = load (file_name, &_if);
+	success = load (cmd_line, &_if);
 
 	/* If load failed, quit. */
-	palloc_free_page (file_name); 	//실행 파일 이름/인자 문자열을 저장하기 위해 커널이 이전에 할당했던 메모리 페이지를 해제
+	palloc_free_page (cmd_line); 	//실행 파일 이름/인자 문자열을 저장하기 위해 커널이 이전에 할당했던 메모리 페이지를 해제
 	if (!success)
 		return -1;
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -418,7 +418,10 @@ unsigned sys_tell(int fd){
 	}
 
 	struct file *cur_file = thread_current()->fd_table[fd];
-
+	if (cur_file == NULL) {
+			return -1; 
+		}
+		
 	lock_acquire(&filesys_lock);
     off_t offset = file_tell(cur_file);
     lock_release(&filesys_lock);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -10,7 +10,8 @@
 #include "threads/synch.h"
 #include "filesys/filesys.h"
 #include "filesys/file.h"
-#include "threads/vaddr.h" // fir PGSIZE
+#include "threads/vaddr.h" // for PGSIZE
+#include "userprog/process.h"
 static struct lock filesys_lock;
 
 void syscall_entry (void);
@@ -70,8 +71,11 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_EXIT:
 			sys_exit(f->R.rdi);
 			break;
-		case SYS_FORK:
+		case SYS_FORK:{
+			const char *thread_name = f->R.rdi;
+			f->R.rax = process_fork(thread_name, f);
 			break;
+		}
 		case SYS_EXEC:
 			break;
 		case SYS_WAIT:
@@ -92,8 +96,8 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_FILESIZE:{
 			int fd = f->R.rdi;
 			f->R.rax = sys_filesize(fd);
-		}
 			break;
+		}
 		case SYS_READ:{
 			int fd = f->R.rdi;
 			void *buffer = f->R.rsi;


### PR DESCRIPTION
## Summary

This PR completes the userprog part of Project 2 and the extra dup2
extension by implementing the full syscall layer, proper process control,
and robust file/FD handling.

The work in this branch includes:

- Per-process file descriptor table
- Core file-related syscalls (open/close/read/write/filesize/seek/tell/remove)
- Fork/wait/exit/exec with correct address-space and FD semantics
- Read-only executables (ROX) via deny-write on active executables
- Safe user memory access for bad-* tests
- dup2 support with stdio sentinels and shared file* semantics


## Details

### File descriptor table & syscalls

- Introduce a per-process `fd_table` instead of using only fixed fd >= 2.
- Implement:
  - `open`, `close`, `read`, `write`, `filesize`, `seek`, `tell`, `remove`
- Validate user pointers via helper functions (e.g. `check_user_str`, `check_user_buffer`).
- Allocate the per-process `fd_table` via `palloc` and initialize it in `init_thread`.
- Initialize new file objects with `ref_cnt = 1` so they can be safely shared.
- Rework all file-related syscalls to:
  - Look up `struct file *` via `fd_table[fd]`
  - Guard filesystem operations with `filesys_lock`


### Fork / wait / exit / exec

- Implement `fork` using `process_fork() → duplicate_pte() → __do_fork()`:
  - Snapshot the parent `intr_frame` using `fork_aux_arg`.
  - Clone the user address space with `pml4_for_each()` + `duplicate_pte()`.
  - Duplicate the parent `fd_table` (with `file_duplicate` for real files).
  - Use semaphores to ensure the parent only returns from `fork()` once the child
    has fully duplicated its resources.
- Implement `wait` using a `child_info` structure and a per-thread `children` list:
  - Track `tid`, `exit_status`, and wait state.
  - Block the parent on a per-child semaphore and return the correct exit status.
- Refine `exit` (`sys_exit()`):
  - Store the child’s exit status in `child_info`.
  - Wake any parent blocked in `wait`.
  - Print the required `"<name>: exit(status)"` line.
- Implement `exec`:
  - Add `sys_exec()` and hook `SYS_EXEC` in `syscall_handler`.
  - Validate and copy `cmd_line` onto a fresh kernel page.
  - Call `process_exec()`, and call `sys_exit(-1)` on failure as per spec.


### ROX: deny write on executables

- Track the current executable via `struct thread::exec_file`.
- In `load()`:
  - Keep the executable file open for the lifetime of the process.
  - Call `file_deny_write()` and store the handle in `exec_file`.
- In `process_exec()`:
  - Allow writes (`file_allow_write`) and close the old `exec_file` before
    replacing the image.
- In `process_exit()`:
  - Allow writes and close `exec_file` when the process terminates.
- In `__do_fork()`:
  - Duplicate `parent->exec_file` for the child and call `file_deny_write()` on
    the duplicated handle so children also respect ROX semantics.


### Robustness: bad-* and user memory faults

- Update `page_fault()` to detect user-mode faults (`PF_U`) and terminate the
  current user process via `sys_exit(-1)` instead of printing kernel diagnostics.
- This ensures user programs that read/write/jump to invalid or kernel addresses
  are cleanly terminated, satisfying all `bad-*` tests.


### dup2 & stdio sentinels

- Introduce `STDIN_SENTINEL` / `STDOUT_SENTINEL` and store them in
  `fd_table[0]` / `fd_table[1]`.
- Implement `sys_dup2()` so:
  - `oldfd` and `newfd` share the same `file *`.
  - `ref_cnt` is incremented only for real file objects (not stdio sentinels).
  - If `newfd` is already open, it is closed first (respecting ref-count logic).
- Adjust:
  - `__do_fork()` to copy the entire `fd_table[0..FD_CAP)`:
    - Shallow-copy stdio sentinels.
    - `file_duplicate()` only for regular files.
  - `process_exit()` to walk all fds, skip stdio sentinels, decrement `ref_cnt`
    for regular files, and only `file_close()` when `ref_cnt == 0`.
- Refactor all file-related syscalls (`read`, `write`, `close`, `filesize`,
  `seek`, `tell`) to dispatch based on `fd_table[fd]`:
  - Special-case `STDIN_SENTINEL` / `STDOUT_SENTINEL`.
  - Treat non-sentinel entries as regular files under `filesys_lock`.


## Tests

All relevant tests for Project 1 (threads parts used here), Project 2 userprog,
base filesys, and dup2 pass.

Rubric summary:

```text
SUMMARY BY TEST SET

Test Set                                      Pts Max  % Ttl  % Max
--------------------------------------------- --- --- ------ ------
tests/threads/Rubric.alarm                      7/  7   2.0%/  2.0%
tests/threads/Rubric.priority                  25/ 25   3.0%/  3.0%
tests/userprog/Rubric.functionality            40/ 40  40.0%/ 40.0%
tests/userprog/Rubric.robustness               40/ 40  30.0%/ 30.0%
tests/userprog/no-vm/Rubric                     3/  3  10.0%/ 10.0%
tests/filesys/base/Rubric                      17/ 17  15.0%/ 15.0%
tests/userprog/dup2/Rubric                      4/  4  20.0%/ 20.0%
--------------------------------------------- --- --- ------ ------
Total                                                 120.0%/120.0%
